### PR TITLE
Update social proof section text and logo order

### DIFF
--- a/app/components/sections/SocialProof.tsx
+++ b/app/components/sections/SocialProof.tsx
@@ -8,7 +8,7 @@ const SocialProof = () => {
   return (
     <div className="mt-8 md:mt-12">
       <AnimatedHeading>
-        TRUSTED BY SMALL BUSINESSES AND FORTUNE 500 COMPANIES
+        TRUSTED BY FORTUNE 500 AND SMALL BUSINESSES
       </AnimatedHeading>
       <AnimatedLogosContainer>
         {trustedCompanies.map((company) => (

--- a/app/lib/data/companies.ts
+++ b/app/lib/data/companies.ts
@@ -1,31 +1,13 @@
 // Company data extracted from SocialProof component
 export const trustedCompanies = [
   {
-    name: "RNL",
-    logo: "/rnl.webp",
-    width: "w-16",
-    height: "h-12",
-    mdWidth: "md:w-16",
-    mdHeight: "md:h-12",
-    sizes: "64px"
-  },
-  {
-    name: "Business Expo Center",
-    logo: "/business-expo-center.webp",
-    width: "w-20",
-    height: "h-12",
-    mdWidth: "md:w-24",
-    mdHeight: "md:h-14",
-    sizes: "96px"
-  },
-  {
-    name: "Glass Doctor",
-    logo: "/glass-doctor.webp",
-    width: "w-20",
-    height: "h-12",
-    mdWidth: "md:w-24",
-    mdHeight: "md:h-14",
-    sizes: "96px"
+    name: "Accenture",
+    logo: "/accenture.webp",
+    width: "w-28",
+    height: "h-24",
+    mdWidth: "md:w-32",
+    mdHeight: "md:h-24",
+    sizes: "128px"
   },
   {
     name: "KnoxLabs",
@@ -37,13 +19,31 @@ export const trustedCompanies = [
     sizes: "144px"
   },
   {
-    name: "Accenture",
-    logo: "/accenture.webp",
-    width: "w-28",
-    height: "h-24",
-    mdWidth: "md:w-32",
-    mdHeight: "md:h-24",
-    sizes: "128px"
+    name: "RNL",
+    logo: "/rnl.webp",
+    width: "w-16",
+    height: "h-12",
+    mdWidth: "md:w-16",
+    mdHeight: "md:h-12",
+    sizes: "64px"
+  },
+  {
+    name: "Glass Doctor",
+    logo: "/glass-doctor.webp",
+    width: "w-20",
+    height: "h-12",
+    mdWidth: "md:w-24",
+    mdHeight: "md:h-14",
+    sizes: "96px"
+  },
+  {
+    name: "Business Expo Center",
+    logo: "/business-expo-center.webp",
+    width: "w-20",
+    height: "h-12",
+    mdWidth: "md:w-24",
+    mdHeight: "md:h-14",
+    sizes: "96px"
   }
 ];
 


### PR DESCRIPTION
## Summary
- Change heading text from "TRUSTED BY SMALL BUSINESSES AND FORTUNE 500 COMPANIES" to "TRUSTED BY FORTUNE 500 AND SMALL BUSINESSES"
- Reorder company logos to display Accenture first, followed by KnoxLabs, RNL, Glass Doctor, and Business Expo Center

## Test plan
- [ ] Verify heading text displays correctly on social proof section
- [ ] Confirm company logos appear in the new order: Accenture → KnoxLabs → RNL → Glass Doctor → Business Expo Center
- [ ] Test on desktop and mobile devices to ensure proper layout

🤖 Generated with [Claude Code](https://claude.ai/code)